### PR TITLE
Standardize GitHub Actions and pkgdown

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,46 +1,36 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 
+permissions:
+  contents: read
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
-
+    runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ github.token }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
+          r-version: release
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-Wasm-check.yaml
+++ b/.github/workflows/R-Wasm-check.yaml
@@ -1,0 +1,26 @@
+# Workflow derived from https://github.com/r-wasm/actions/tree/v3/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: R-Wasm-check
+
+permissions:
+  contents: read
+
+jobs:
+  R-Wasm-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build package for WebAssembly
+        uses: r-wasm/actions/build-rwasm@v3
+        with:
+          packages: "."

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,61 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 on:
   push:
-    branches:
-      - main
-      - master
-    tags:
-      -'*'
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
+permissions:
+  contents: write
+
 jobs:
   pkgdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
-      - uses: r-lib/actions/setup-r@v1
-        id: install-r
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Install pak and query dependencies
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: |
-            ${{ env.R_LIBS_USER }}/*
-            !${{ env.R_LIBS_USER }}/pak
-          key: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-1-
+          r-version: release
+          use-public-rspm: true
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("pkgdown", execute = TRUE)
-          pak::local_install_dev_deps(upgrade = TRUE, dependencies = c("all", "Config/Needs/website"))
-          pak::pkg_install("pkgdown")          
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
 
       - name: Build site
-        run: pkgdown::build_site()          
         shell: Rscript {0}
-        
-      - name: Deploy package
+        run: pkgdown::build_site()
+
+      - name: Deploy site
+        if: github.event_name != 'pull_request'
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'      
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,16 +4,24 @@ authors:
   Joshua Kunst:
     href: https://jkunst.com
 
+lang: en
+
 template:
   bootstrap: 5
   bslib:
-    primary: "#0054AD"
+    primary: "#5B4B8A"
     border-radius: 0.5rem
     btn-border-radius: 0.25rem
-    base_font:    {google: "IBM Plex Sans"}
-    code_font:    {google: "Fira Mono"}
-    heading_font: {google: "Josefin Sans"}
-    # https://github.com/rstudio/bslib/blob/a4946a4/inst/lib/bs4/scss/_variables.scss
-    headings-color:  "#333333"
-    headings-line-height: 5rem
-    headings-margin-bottom: -1rem
+    base_font:
+      google: "IBM Plex Sans"
+    heading_font:
+      google: "IBM Plex Sans"
+    code_font:
+      google: "Fira Mono"
+    headings-color: "#40375F"
+    headings-line-height: 1.2
+    headings-margin-bottom: 0.75rem
+
+navbar:
+  bg: primary
+  type: dark


### PR DESCRIPTION
## Summary

- simplify R-CMD-check to Ubuntu with R release
- replace the legacy Ubuntu 18.04 pkgdown workflow with the shared workflow
- use actions/checkout@v5 and r-lib/actions v2 consistently
- add a WebAssembly package build with r-wasm/actions/build-rwasm@v3
- normalize the pkgdown typography, spacing and calendar-inspired color

## Scope

Infrastructure and pkgdown styling only. No package logic was changed.

## Checks

- R-CMD-check
- pkgdown build
- WebAssembly package build
